### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code ownership for this repository
+* @Invoca/calls

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mrcp-api
+  title: mrcp-api
+  description: "Docker-compose for LumenVox MRCP API (Media Server)"
+  tags:
+    - shell
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/mrcp-api/
+    github.com/project-slug: Invoca/mrcp-api
+    buildkite.com/project-slug: invoca/mrcp-api
+spec:
+  type: service
+  lifecycle: production
+  owner: calls
+  system: telephony-system


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `service` (inferred from repo name/language)
- **owner**: `calls`
- **system**: `telephony-system`

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://backstage.invocaops.com/catalog/default/system/?filters%5Bkind%5D=system&filters%5Buser%5D=all&limit=20))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
